### PR TITLE
Use new format for sentry configuration

### DIFF
--- a/docs/resources/catalog_entity.md
+++ b/docs/resources/catalog_entity.md
@@ -515,9 +515,18 @@ Required:
 <a id="nestedatt--sentry"></a>
 ### Nested Schema for `sentry`
 
+Optional:
+
+- `project` (String) (Deprecated) Sentry project ID for the entity. Use `projects` instead.
+- `projects` (Attributes List) List of Sentry projects for the entity. (see [below for nested schema](#nestedatt--sentry--projects))
+
+<a id="nestedatt--sentry--projects"></a>
+### Nested Schema for `sentry.projects`
+
 Required:
 
-- `project` (String) Sentry project ID for the entity.
+- `name` (String) Sentry project ID.
+
 
 
 <a id="nestedatt--service_now"></a>

--- a/examples/resources/catalog_entity/resource.tf
+++ b/examples/resources/catalog_entity/resource.tf
@@ -335,6 +335,15 @@ resource "cortex_catalog_entity" "products-service" {
 
   sentry = {
     project = "products-service"
+    // or
+    projects = [
+      {
+        name = "products-service"
+      },
+      {
+        name = "projects-sub-service"
+      }
+    ]
   }
 
   snyk = {

--- a/internal/cortex/catalog_entity_parser.go
+++ b/internal/cortex/catalog_entity_parser.go
@@ -569,6 +569,18 @@ func (c *CatalogEntityParser) interpolateMicrosoftTeams(entity *CatalogEntityDat
 
 func (c *CatalogEntityParser) interpolateSentry(entity *CatalogEntityData, sentryMap map[string]interface{}) {
 	entity.Sentry.Project = MapFetchToString(sentryMap, "project")
+	if sentryMap["projects"] != nil {
+		for _, project := range sentryMap["projects"].([]interface{}) {
+			projectMap := project.(map[string]interface{})
+			sp := CatalogEntitySentryProject{}
+			if projectMap["name"] != nil {
+				sp.Name = MapFetchToString(projectMap, "name")
+			}
+			if sp.Enabled() {
+				entity.Sentry.Projects = append(entity.Sentry.Projects, sp)
+			}
+		}
+	}
 }
 
 /***********************************************************************************************************************

--- a/internal/cortex/integrations.go
+++ b/internal/cortex/integrations.go
@@ -663,11 +663,20 @@ type CatalogEntitySLOSignalFX struct {
  **********************************************************************************************************************/
 
 type CatalogEntitySentry struct {
-	Project string `json:"project" yaml:"project"`
+	Project  string                       `json:"project,omitempty" yaml:"project,omitempty"`
+	Projects []CatalogEntitySentryProject `json:"projects,omitempty" yaml:"projects,omitempty"`
 }
 
 func (o *CatalogEntitySentry) Enabled() bool {
-	return o.Project != ""
+	return o.Project != "" || len(o.Projects) > 0
+}
+
+type CatalogEntitySentryProject struct {
+	Name string `json:"name" yaml:"name"`
+}
+
+func (o *CatalogEntitySentryProject) Enabled() bool {
+	return o.Name != ""
 }
 
 /***********************************************************************************************************************

--- a/internal/provider/catalog_entity_resource.go
+++ b/internal/provider/catalog_entity_resource.go
@@ -969,8 +969,20 @@ func (r *CatalogEntityResource) Schema(ctx context.Context, req resource.SchemaR
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"project": schema.StringAttribute{
-						MarkdownDescription: "Sentry project ID for the entity.",
-						Required:            true,
+						MarkdownDescription: "(Deprecated) Sentry project ID for the entity. Use `projects` instead.",
+						Optional:            true,
+					},
+					"projects": schema.ListNestedAttribute{
+						MarkdownDescription: "List of Sentry projects for the entity.",
+						Optional:            true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"name": schema.StringAttribute{
+									MarkdownDescription: "Sentry project ID.",
+									Required:            true,
+								},
+							},
+						},
 					},
 				},
 			},

--- a/internal/provider/catalog_entity_resource_test.go
+++ b/internal/provider/catalog_entity_resource_test.go
@@ -237,7 +237,7 @@ func TestAccCatalogEntityResourceComplete(t *testing.T) {
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "ci_cd.buildkite.tags.0.tag", "products-tag"),
 
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "bug_snag.project", "cortexio/products-service"),
-					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "sentry.project", "cortexio/products-service"),
+					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "sentry.projects.0.name", "cortexio/products-service"),
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "checkmarx.projects.0.name", "products-service"),
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "firehydrant.services.0.id", "asdf1234"),
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "firehydrant.services.0.type", "ID"),
@@ -549,7 +549,7 @@ resource "cortex_catalog_entity" "test" {
   }
 
   sentry = {
-    project = "cortexio/products-service"
+    projects = [{ name = "cortexio/products-service" }]
   }
 
   snyk = {


### PR DESCRIPTION
Cortex has changed its format for sentry project configuration to allow for multiple projects associated with an entity. This adapts the TF provider to accomodate for that.

e.g.:

```
    projects = [
      {
        name = "my-service"
      },
      {
        name = "another-service"
      }
    ]
```