### PR TITLE
Various bugfixes

### DIFF
--- a/docs/resources/catalog_entity.md
+++ b/docs/resources/catalog_entity.md
@@ -492,7 +492,7 @@ Required:
 
 Required:
 
-- `type` (String) Type of owner. Valid values are `EMAIL`, `GROUP`, `OKTA`, or `SLACK`.
+- `type` (String) Type of owner. Valid values are `EMAIL`, `GROUP`, or `SLACK`.
 
 Optional:
 

--- a/docs/resources/resource_definition.md
+++ b/docs/resources/resource_definition.md
@@ -19,7 +19,6 @@ ResourceDefinition Entity
 
 - `name` (String) Name of the team.
 - `schema` (String) Schema for the resource definition.
-- `source` (String) Source of the resource definition. Either "CORTEX" or "CUSTOM".
 - `type` (String) Unique identifier for the resource definition.
 
 ### Optional
@@ -29,3 +28,4 @@ ResourceDefinition Entity
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `source` (String) Source of the resource definition. Either "CORTEX" or "CUSTOM".

--- a/examples/resources/catalog_entity/resource.tf
+++ b/examples/resources/catalog_entity/resource.tf
@@ -7,7 +7,7 @@ resource "cortex_catalog_entity" "products-service" {
   owners = [
     {
       name  = "John Doe"
-      type  = "user"
+      type  = "email"
       email = "john.doe@cortex.io"
     },
     {
@@ -253,13 +253,13 @@ resource "cortex_catalog_entity" "products-service" {
     }
   }
 
-  bugsnag = {
+  bug_snag = {
     project = "products-service"
   }
 
   checkmarx = {
     projects = [
-      { id = "products-service" }
+      { name = "products-service" }
     ]
   }
 

--- a/internal/cortex/catalog_entity_parser.go
+++ b/internal/cortex/catalog_entity_parser.go
@@ -275,7 +275,7 @@ func (c *CatalogEntityParser) interpolateGit(entity *CatalogEntityData, gitMap m
 		githubMap := gitMap["github"].(map[string]interface{})
 		entity.Git.Github = CatalogEntityGitGithub{
 			Repository: MapFetchToString(githubMap, "repository"),
-			BasePath:   MapFetchToString(githubMap, "basePath"),
+			BasePath:   MapFetchToString(githubMap, "basepath"),
 		}
 	} else {
 		entity.Git.Github = CatalogEntityGitGithub{}
@@ -284,7 +284,7 @@ func (c *CatalogEntityParser) interpolateGit(entity *CatalogEntityData, gitMap m
 		gitlabMap := gitMap["gitlab"].(map[string]interface{})
 		entity.Git.Gitlab = CatalogEntityGitGitlab{
 			Repository: MapFetchToString(gitlabMap, "repository"),
-			BasePath:   MapFetchToString(gitlabMap, "basePath"),
+			BasePath:   MapFetchToString(gitlabMap, "basepath"),
 		}
 	} else {
 		entity.Git.Gitlab = CatalogEntityGitGitlab{}
@@ -294,7 +294,7 @@ func (c *CatalogEntityParser) interpolateGit(entity *CatalogEntityData, gitMap m
 		entity.Git.Azure = CatalogEntityGitAzureDevOps{
 			Project:    MapFetchToString(azureMap, "project"),
 			Repository: MapFetchToString(azureMap, "repository"),
-			BasePath:   MapFetchToString(azureMap, "basePath"),
+			BasePath:   MapFetchToString(azureMap, "basepath"),
 		}
 	} else {
 		entity.Git.Azure = CatalogEntityGitAzureDevOps{}
@@ -891,6 +891,7 @@ func (c *CatalogEntityParser) interpolateStaticAnalysisMend(entity *CatalogEntit
 func (c *CatalogEntityParser) interpolateStaticAnalysisSonarQube(entity *CatalogEntityData, data map[string]interface{}) {
 	entity.StaticAnalysis.SonarQube = CatalogEntityStaticAnalysisSonarQube{
 		Project: data["project"].(string),
+		Alias:   data["alias"].(string),
 	}
 }
 

--- a/internal/cortex/catalog_entity_parser.go
+++ b/internal/cortex/catalog_entity_parser.go
@@ -889,10 +889,7 @@ func (c *CatalogEntityParser) interpolateStaticAnalysisMend(entity *CatalogEntit
 // SonarQube
 
 func (c *CatalogEntityParser) interpolateStaticAnalysisSonarQube(entity *CatalogEntityData, data map[string]interface{}) {
-	entity.StaticAnalysis.SonarQube = CatalogEntityStaticAnalysisSonarQube{
-		Project: data["project"].(string),
-	}
-
+	entity.StaticAnalysis.SonarQube.Project = data["project"].(string)
 	if data["alias"] != nil {
 		entity.StaticAnalysis.SonarQube.Alias = data["alias"].(string)
 	}

--- a/internal/cortex/catalog_entity_parser.go
+++ b/internal/cortex/catalog_entity_parser.go
@@ -891,7 +891,10 @@ func (c *CatalogEntityParser) interpolateStaticAnalysisMend(entity *CatalogEntit
 func (c *CatalogEntityParser) interpolateStaticAnalysisSonarQube(entity *CatalogEntityData, data map[string]interface{}) {
 	entity.StaticAnalysis.SonarQube = CatalogEntityStaticAnalysisSonarQube{
 		Project: data["project"].(string),
-		Alias:   data["alias"].(string),
+	}
+
+	if data["alias"] != nil {
+		entity.StaticAnalysis.SonarQube.Alias = data["alias"].(string)
 	}
 }
 

--- a/internal/cortex/resource_definitions.go
+++ b/internal/cortex/resource_definitions.go
@@ -185,12 +185,12 @@ func (c *ResourceDefinitionsClient) Update(ctx context.Context, typeName string,
 type DeleteResourceDefinitionResponse struct{}
 
 func (c *ResourceDefinitionsClient) Delete(ctx context.Context, typeName string) error {
-	scorecardResponse := DeleteResourceDefinitionResponse{}
+	deleteDefinitionResponse := DeleteResourceDefinitionResponse{}
 	apiError := ApiError{}
 
-	response, err := c.Client().Delete(Route("resource_definitions", typeName)).Receive(&scorecardResponse, &apiError)
+	response, err := c.Client().Delete(Route("resource_definitions", typeName)).Receive(&deleteDefinitionResponse, &apiError)
 	if err != nil {
-		return errors.New("could not delete scorecard: " + err.Error())
+		return errors.New("could not delete resource definition: " + err.Error())
 	}
 
 	err = c.client.handleResponseStatus(response, &apiError)

--- a/internal/provider/catalog_entity_resource.go
+++ b/internal/provider/catalog_entity_resource.go
@@ -87,10 +87,10 @@ func (r *CatalogEntityResource) Schema(ctx context.Context, req resource.SchemaR
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
-							MarkdownDescription: "Type of owner. Valid values are `EMAIL`, `GROUP`, `OKTA`, or `SLACK`.",
+							MarkdownDescription: "Type of owner. Valid values are `EMAIL`, `GROUP`, or `SLACK`.",
 							Required:            true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("EMAIL", "GROUP", "OKTA", "SLACK"),
+								stringvalidator.OneOfCaseInsensitive("EMAIL", "GROUP", "SLACK"),
 							},
 						},
 						"name": schema.StringAttribute{
@@ -109,7 +109,7 @@ func (r *CatalogEntityResource) Schema(ctx context.Context, req resource.SchemaR
 							MarkdownDescription: "Provider of the owner. Only allowed if `type` is `group`.",
 							Optional:            true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("ACTIVE_DIRECTORY", "BAMBOO_HR", "CORTEX", "GITHUB", "GOOGLE", "OKTA", "OPSGENIE", "WORKDAY"),
+								stringvalidator.OneOf("ACTIVE_DIRECTORY", "BAMBOO_HR", "CORTEX", "GITHUB", "GITLAB", "GOOGLE", "OKTA", "OPSGENIE", "SERVICE_NOW", "WORKDAY"),
 							},
 						},
 						"channel": schema.StringAttribute{

--- a/internal/provider/catalog_entity_resource_models.go
+++ b/internal/provider/catalog_entity_resource_models.go
@@ -483,7 +483,7 @@ type CatalogEntityOwnerResourceModel struct {
 
 func (o *CatalogEntityOwnerResourceModel) ToApiModel() cortex.CatalogEntityOwner {
 	switch strings.ToLower(o.Type.ValueString()) {
-	case "user", "email":
+	case "email":
 		return cortex.CatalogEntityOwner{
 			Type:        o.Type.ValueString(),
 			Name:        o.Name.ValueString(),
@@ -517,7 +517,7 @@ func (o *CatalogEntityOwnerResourceModel) FromApiModel(owner *cortex.CatalogEnti
 	}
 
 	switch strings.ToLower(owner.Type) {
-	case "user", "email":
+	case "email":
 		obj.Email = types.StringValue(owner.Email)
 		obj.Channel = types.StringNull()
 		obj.Name = types.StringValue(owner.Name)
@@ -3078,7 +3078,7 @@ func (o *CatalogEntityStaticAnalysisCodeCovResourceModel) ToApiModel() cortex.Ca
 	return cortex.CatalogEntityStaticAnalysisCodeCov{
 		Repository: o.Repository.ValueString(),
 		Provider:   o.Provider.ValueString(),
-		Owner:      o.Provider.ValueString(),
+		Owner:      o.Owner.ValueString(),
 		Flag:       o.Flag.ValueString(),
 	}
 }

--- a/internal/provider/resource_definition_resource.go
+++ b/internal/provider/resource_definition_resource.go
@@ -62,7 +62,7 @@ func (r *ResourceDefinitionResource) Schema(ctx context.Context, req resource.Sc
 			},
 			"source": schema.StringAttribute{
 				MarkdownDescription: "Source of the resource definition. Either \"CORTEX\" or \"CUSTOM\".",
-				Required:            true,
+				Computed:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive("CORTEX", "CUSTOM"),
 				},

--- a/internal/provider/resource_definition_resource_test.go
+++ b/internal/provider/resource_definition_resource_test.go
@@ -37,7 +37,6 @@ func TestAccResourceDefinitionResourceMinimal(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "type", stub.Type),
 					resource.TestCheckResourceAttr(resourceName, "name", stub.Name),
-					resource.TestCheckResourceAttr(resourceName, "source", "CUSTOM"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -51,7 +50,6 @@ resource "cortex_resource_definition" %1[1]q {
  type = %[1]q
  name = %[2]q
  description = %[3]q
- source = "CUSTOM"
  schema = jsonencode({
 	"properties": {
 	  "region": {

--- a/internal/provider/resource_definition_resource_test.go
+++ b/internal/provider/resource_definition_resource_test.go
@@ -23,7 +23,6 @@ func TestAccResourceDefinitionResourceMinimal(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "type", stub.Type),
 					resource.TestCheckResourceAttr(resourceName, "name", stub.Name),
-					resource.TestCheckResourceAttr(resourceName, "source", "CUSTOM"),
 				),
 			},
 			// ImportState testing


### PR DESCRIPTION
* Fix incorrect examples
* Fix serialization of `basepath` in git repos for `cortex_catalog_entity`s
* Fix serialization of `alias` in sonarqube for `cortex_catalog_entity`s
* Fix serialization of `owner` in codecov for `cortex_catalog_entity`s
* Fix case sensitivity of owner type for `cortex_catalog_entity`s