### PR TITLE
Added functionality to return back the children of a team or domain w…

### DIFF
--- a/internal/provider/catalog_entity_data_source_test.go
+++ b/internal/provider/catalog_entity_data_source_test.go
@@ -24,9 +24,37 @@ func TestAccCatalogEntityDataSource(t *testing.T) {
 	})
 }
 
+func TestAccCatalogDomainDataSource(t *testing.T) {
+	recordName := "data.cortex_catalog_entity.domain-manual-test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read testing
+			{
+				Config: testAccCatalogDomainEntityDataSourceBasic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(recordName, "tag", "domain-manual-test"),
+					resource.TestCheckResourceAttr(recordName, "name", "Manual Test Domain"),
+					resource.TestCheckResourceAttr(recordName, "description", "A manual domain for data source testing. DO NOT DELETE."),
+					resource.TestCheckResourceAttr(recordName, "children.#", "1"),
+					resource.TestCheckResourceAttr(recordName, "children.0.tag", "manual-test"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCatalogEntityDataSourceBasic() string {
 	return `
 data "cortex_catalog_entity" "manual-test" {
 	tag = "manual-test"
+}`
+}
+
+func testAccCatalogDomainEntityDataSourceBasic() string {
+	return `
+data "cortex_catalog_entity" "domain-manual-test" {
+	tag = "domain-manual-test"
 }`
 }


### PR DESCRIPTION
…hen calling the cortex_catalog_entity data source

In order for the tests to pass you need to add a new a new domain with the following domain yaml file to the test account.


```
openapi: 3.0.1
info:
  title: Manual Test Domain
  description: A manual domain for data source testing. DO NOT DELETE.
  x-cortex-tag: domain-manual-test
  x-cortex-type: domain
  x-cortex-children:
  - tag: manual-test
```
