### PR TITLE
Update scorecard description and filter to be computed to avoid inconsistent state/api results

### DIFF
--- a/internal/provider/scorecard_resource.go
+++ b/internal/provider/scorecard_resource.go
@@ -123,6 +123,7 @@ func (r *ScorecardResource) Schema(ctx context.Context, req resource.SchemaReque
 			"description": schema.StringAttribute{
 				MarkdownDescription: "Description of the scorecard.",
 				Optional:            true,
+				Computed:            true,
 			},
 			"draft": schema.BoolAttribute{
 				MarkdownDescription: "Whether the scorecard is a draft.",
@@ -131,6 +132,7 @@ func (r *ScorecardResource) Schema(ctx context.Context, req resource.SchemaReque
 			"filter": schema.SingleNestedAttribute{
 				MarkdownDescription: "Filter of the scorecard.",
 				Optional:            true,
+				Computed:            true,
 				Attributes: map[string]schema.Attribute{
 					"category": schema.StringAttribute{
 						MarkdownDescription: "By default, Scorecards are evaluated against all services. You can specify the category as RESOURCE to evaluate a Scorecard against resources or DOMAIN to evaluate a Scorecard against domains.",

--- a/internal/provider/scorecard_resource.go
+++ b/internal/provider/scorecard_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/cortexapps/terraform-provider-cortex/internal/cortex"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -108,7 +108,7 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing without description or filter
 			{
-				Config: stub.ToTerraform(),
+				Config: stub.ToTerraformWithoutDescriptionOrFilter(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "tag", stub.Tag),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "name", stub.Name),

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -128,9 +128,6 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "evaluation.window", "24"),
 
-					// Check that description exists but don't check its value
-					resource.TestCheckResourceAttrSet(stub.ResourceFullName(), "description"),
-
 					// Check that filter exists and has a category, but don't check specific values
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "filter.category", "SERVICE"),
 				),

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -90,6 +90,10 @@ resource %[1]q %[2]q {
   evaluation = {
     window = 24
   }
+
+  lifecycle {
+    ignore_changes = [description, filter]
+  }
 }`, t.ResourceType(), t.Tag, t.Name, t.Draft)
 }
 
@@ -112,7 +116,6 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "tag", stub.Tag),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "name", stub.Name),
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "description", ""),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "draft", fmt.Sprintf("%t", stub.Draft)),
 
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.title", "Has a Description"),

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -108,8 +108,8 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing without description or filter
 			{
-				Config:                  stub.ToTerraformWithoutDescriptionOrFilter(),
-				ImportStateVerifyIgnore: []string{"description", "filter"},
+				Config:             stub.ToTerraformWithoutDescriptionOrFilter(),
+				ExpectNonEmptyPlan: false,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "tag", stub.Tag),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "name", stub.Name),
@@ -130,6 +130,16 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 
 					// Check that filter exists and has a category, but don't check specific values
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "filter.category", "SERVICE"),
+				),
+			},
+			// Assuming still valid
+			{
+				Config:             stub.ToTerraformWithoutDescriptionOrFilter(),
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "tag", stub.Tag),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "name", stub.Name),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "draft", fmt.Sprintf("%t", stub.Draft)),
 				),
 			},
 			// Read testing

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -129,10 +129,10 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "evaluation.window", "24"),
 
 					// Check that description exists but don't check its value
-					resource.TestCheckResourceAttrSet("cortex_scorecard.test-complete-scorecard", "description"),
+					resource.TestCheckResourceAttrSet(stub.ResourceFullName(), "description"),
 
 					// Check that filter exists and has a category, but don't check specific values
-					resource.TestCheckResourceAttrSet("cortex_scorecard.test-complete-scorecard", "filter"),
+					resource.TestCheckResourceAttrSet(stub.ResourceFullName(), "filter.category", "SERVICE"),
 				),
 			},
 			// Read testing

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -2,8 +2,9 @@ package provider_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 type testScorecardResource struct {
@@ -61,6 +62,37 @@ resource %[1]q %[2]q {
 }`, t.ResourceType(), t.Tag, t.Name, t.Description, t.Draft)
 }
 
+func (t *testScorecardResource) ToTerraformWithoutDescriptionOrFilter() string {
+	return fmt.Sprintf(`
+resource %[1]q %[2]q {
+  tag = %[2]q
+  name = %[3]q
+  draft = %[4]t
+  rules = [
+    {
+      title = "Has a Description"
+      expression = "description != null"
+      weight = 1
+      level = "Bronze"
+      failure_message = "The description is required"
+      description = "The service has a description"
+    }
+  ]
+  ladder = {
+    levels = [
+      {
+         name = "Bronze"
+         rank = 1
+         color = "#c38b5f"
+      }
+    ]
+  }
+  evaluation = {
+    window = 24
+  }
+}`, t.ResourceType(), t.Tag, t.Name, t.Draft)
+}
+
 /***********************************************************************************************************************
  * Tests
  **********************************************************************************************************************/
@@ -74,6 +106,32 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
+			// Read testing without description or filter
+			{
+				Config: stub.ToTerraform(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "tag", stub.Tag),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "name", stub.Name),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "description", stub.Description),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "draft", fmt.Sprintf("%t", stub.Draft)),
+
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.title", "Has a Description"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.expression", "description != null"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.weight", "1"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.level", "Bronze"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.failure_message", "The description is required"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.description", "The service has a description"),
+
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.name", "Bronze"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.rank", "1"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.color", "#c38b5f"),
+
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "filter.category", "SERVICE"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "filter.query", "owners_is_set"),
+
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "evaluation.window", "24"),
+				),
+			},
 			// Read testing
 			{
 				Config: stub.ToTerraform(),

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -132,7 +132,7 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 					resource.TestCheckResourceAttrSet(stub.ResourceFullName(), "description"),
 
 					// Check that filter exists and has a category, but don't check specific values
-					resource.TestCheckResourceAttrSet(stub.ResourceFullName(), "filter.category", "SERVICE"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "filter.category", "SERVICE"),
 				),
 			},
 			// Read testing

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -90,10 +90,6 @@ resource %[1]q %[2]q {
   evaluation = {
     window = 24
   }
-
-  lifecycle {
-    ignore_changes = [description, filter]
-  }
 }`, t.ResourceType(), t.Tag, t.Name, t.Draft)
 }
 
@@ -112,7 +108,8 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing without description or filter
 			{
-				Config: stub.ToTerraformWithoutDescriptionOrFilter(),
+				Config:                  stub.ToTerraformWithoutDescriptionOrFilter(),
+				ImportStateVerifyIgnore: []string{"description", "filter"},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "tag", stub.Tag),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "name", stub.Name),
@@ -130,6 +127,12 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.color", "#c38b5f"),
 
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "evaluation.window", "24"),
+
+					// Check that description exists but don't check its value
+					resource.TestCheckResourceAttrSet("cortex_scorecard.test-complete-scorecard", "description"),
+
+					// Check that filter exists and has a category, but don't check specific values
+					resource.TestCheckResourceAttrSet("cortex_scorecard.test-complete-scorecard", "filter"),
 				),
 			},
 			// Read testing

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -90,6 +90,10 @@ resource %[1]q %[2]q {
   evaluation = {
     window = 24
   }
+
+  lifecycle {
+    ignore_changes = [description, filter]
+  }
 }`, t.ResourceType(), t.Tag, t.Name, t.Draft)
 }
 
@@ -113,6 +117,22 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "tag", stub.Tag),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "name", stub.Name),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "draft", fmt.Sprintf("%t", stub.Draft)),
+
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.title", "Has a Description"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.expression", "description != null"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.weight", "1"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.level", "Bronze"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.failure_message", "The description is required"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.description", "The service has a description"),
+
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.name", "Bronze"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.rank", "1"),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.color", "#c38b5f"),
+
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "evaluation.window", "24"),
+
+					// Check that filter exists and has a category, but don't check specific values
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "filter.category", "SERVICE"),
 				),
 			},
 			// Read testing

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -112,7 +112,7 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "tag", stub.Tag),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "name", stub.Name),
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "description", stub.Description),
+					resource.TestCheckResourceAttr(stub.ResourceFullName(), "description", ""),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "draft", fmt.Sprintf("%t", stub.Draft)),
 
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.title", "Has a Description"),
@@ -127,7 +127,6 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.color", "#c38b5f"),
 
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "filter.category", "SERVICE"),
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "filter.query", "owners_is_set"),
 
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "evaluation.window", "24"),
 				),

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -126,8 +126,6 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.rank", "1"),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.color", "#c38b5f"),
 
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "filter.category", "SERVICE"),
-
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "evaluation.window", "24"),
 				),
 			},

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -108,34 +108,7 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing without description or filter
 			{
-				Config:             stub.ToTerraformWithoutDescriptionOrFilter(),
-				ExpectNonEmptyPlan: false,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "tag", stub.Tag),
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "name", stub.Name),
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "draft", fmt.Sprintf("%t", stub.Draft)),
-
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.title", "Has a Description"),
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.expression", "description != null"),
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.weight", "1"),
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.level", "Bronze"),
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.failure_message", "The description is required"),
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "rules.0.description", "The service has a description"),
-
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.name", "Bronze"),
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.rank", "1"),
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.0.color", "#c38b5f"),
-
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "evaluation.window", "24"),
-
-					// Check that filter exists and has a category, but don't check specific values
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "filter.category", "SERVICE"),
-				),
-			},
-			// Assuming still valid
-			{
-				Config:             stub.ToTerraformWithoutDescriptionOrFilter(),
-				ExpectNonEmptyPlan: true,
+				Config: stub.ToTerraformWithoutDescriptionOrFilter(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "tag", stub.Tag),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "name", stub.Name),


### PR DESCRIPTION
Aims to address https://github.com/cortexapps/terraform-provider-cortex/issues/34

Specifies that scorecard `description` and `filter` are both computed meaning that if nothing is explicitly provided then the provider value will be used for the state.