### PR TITLE
Swap changelog.skip -> changelog.disable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,4 +58,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
https://github.com/goreleaser/goreleaser/commit/765d534c2e480c7e1d15272a71250843e3823b43#diff-f44222bbec4dfc4dff445a631f78de4b4ccc9f5bf6588a79b7946c219cc19200L494-R529

Property changed to `disable`, this is breaking releases