### PR TITLE
feat: Update test requirements for PRs and `main`

### DIFF
--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -44,4 +44,4 @@ jobs:
         env:
           TF_ACC: "1"
           CORTEX_API_TOKEN: ${{ secrets.CORTEX_API_TOKEN }}
-        run: make testacc
+        run: go test -v -cover ./...

--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -1,0 +1,47 @@
+# Runs acceptance tests on merge to main
+name: Acceptance Tests
+
+on:
+  push:
+    branches:
+      - "main"
+      - "akwirick/fix-testing-requirements" # TODO remove post-verification
+    paths-ignore:
+      - "README.md"
+      - "CHANGELOG.md"
+      - "TODO.md"
+
+permissions:
+  contents: read
+
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/test.yml
+  acceptance-test:
+    name: Terraform Provider Acceptance Tests
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # list whatever Terraform versions here you would like to support
+        terraform:
+          - "1.10.*"
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-go@v5.3.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - uses: hashicorp/setup-terraform@v3.1.2
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      - run: go mod download
+      - name: Acceptance tests
+        env:
+          TF_ACC: "1"
+          CORTEX_API_TOKEN: ${{ secrets.CORTEX_API_TOKEN }}
+        run: make testacc

--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - "main"
-      - "akwirick/fix-testing-requirements" # TODO remove post-verification
     paths-ignore:
       - "README.md"
       - "CHANGELOG.md"
@@ -23,12 +22,6 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - "1.10.*"
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-go@v5.3.0
@@ -37,7 +30,7 @@ jobs:
           cache: true
       - uses: hashicorp/setup-terraform@v3.1.2
         with:
-          terraform_version: ${{ matrix.terraform }}
+          terraform_version: "1.10.*"
           terraform_wrapper: false
       - run: go mod download
       - name: Acceptance tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,6 @@ name: Tests
 # Optionally, you can turn it on using a schedule for regular testing.
 on:
   pull_request:
-  push:
-    branches:
-      - "main"
-    paths-ignore:
-      - "README.md"
-      - "CHANGELOG.md"
-      - "TODO.md"
 
 # Testing only needs permissions to read the repository contents.
 permissions:
@@ -50,7 +43,7 @@ jobs:
           cache: true
       - uses: hashicorp/setup-terraform@v3.1.2
         with:
-          terraform_version: ${{ matrix.terraform }}
+          terraform_version: "1.10.*"
           terraform_wrapper: false
       - run: go generate ./...
       - name: git diff
@@ -60,29 +53,16 @@ jobs:
 
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
-    name: Terraform Provider Acceptance Tests
+    name: Unit Test
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - "1.10.*"
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-go@v5.3.0
         with:
           go-version-file: "go.mod"
           cache: true
-      - uses: hashicorp/setup-terraform@v3.1.2
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
       - run: go mod download
-      - env:
-          TF_ACC: "1"
-          CORTEX_API_TOKEN: ${{ secrets.CORTEX_API_TOKEN }}
-        run: go test -v -cover ./... # later, change to: ./internal/provider/
-        timeout-minutes: 10
+      - name: Unit tests
+        run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,4 +66,4 @@ jobs:
           cache: true
       - run: go mod download
       - name: Unit tests
-        run: make test
+        run: go test -v -cover ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ name: Tests
 # Optionally, you can turn it on using a schedule for regular testing.
 on:
   pull_request:
+  workflow_call:
 
 # Testing only needs permissions to read the repository contents.
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           cache: true
       - uses: hashicorp/setup-terraform@v3.1.2
         with:
-          terraform_version: ${{ matrix.terraform }}
+          terraform_version: "1.10.*"
           terraform_wrapper: false
       - run: go mod download
       - run: go build -v .
@@ -52,7 +52,7 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
 
-  # Run acceptance tests in a matrix with Terraform CLI versions
+  # Run unit tests
   test:
     name: Unit Test
     needs: build

--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,4 @@ test:
 # acceptance tests
 testacc:
 	go clean -testcache
-	TF_LOG=$(TF_LOG) TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+	TF_LOG=$(TF_LOG) TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 10m


### PR DESCRIPTION
We want to perform both unit and acceptance testing in this repository.   As covered in #47, our acceptance tests require a first-party action run since the `CORTEX_API` is a secret.   

This change facilitates that by providing a lighter path to PR (without acceptance tests) and then a firmer check on acceptance testing in `main`.   This _does_ mean that we could have a PR that breaks main, but this is preferable to exposing secrets and/or having to run an integration environment for every PR.   