### PR TITLE
Remove category usage in tests, add deprecation

### DIFF
--- a/docs/resources/scorecard.md
+++ b/docs/resources/scorecard.md
@@ -84,5 +84,5 @@ Optional:
 
 Optional:
 
-- `category` (String) By default, Scorecards are evaluated against all services. You can specify the category as RESOURCE to evaluate a Scorecard against resources or DOMAIN to evaluate a Scorecard against domains.
+- `category` (String, Deprecated) By default, Scorecards are evaluated against all services. You can specify the category as RESOURCE to evaluate a Scorecard against resources or DOMAIN to evaluate a Scorecard against domains.
 - `query` (String) A CQL query that is run against the category; only entities matching this query will be evaluated by the Scorecard.

--- a/internal/provider/scorecard_resource.go
+++ b/internal/provider/scorecard_resource.go
@@ -141,6 +141,7 @@ func (r *ScorecardResource) Schema(ctx context.Context, req resource.SchemaReque
 					"category": schema.StringAttribute{
 						MarkdownDescription: "By default, Scorecards are evaluated against all services. You can specify the category as RESOURCE to evaluate a Scorecard against resources or DOMAIN to evaluate a Scorecard against domains.",
 						Optional:            true,
+						DeprecationMessage:  "`category` is deprecated and will be removed in a future release.  Forthcoming filters will use the include/exclude functionality that is more commonly used",
 					},
 					"query": schema.StringAttribute{
 						MarkdownDescription: "A CQL query that is run against the category; only entities matching this query will be evaluated by the Scorecard.",

--- a/internal/provider/scorecard_resource_test.go
+++ b/internal/provider/scorecard_resource_test.go
@@ -127,7 +127,6 @@ resource %[1]q %[2]q {
     ]
   }
   filter = {
-    category = "SERVICE"
     query = "owners_is_set"
   }
   evaluation = {
@@ -220,7 +219,6 @@ func TestAccScorecardResourceComplete(t *testing.T) {
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.1.rank", "2"),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "ladder.levels.1.color", "#c3c3c3"),
 
-					resource.TestCheckResourceAttr(stub.ResourceFullName(), "filter.category", "SERVICE"),
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "filter.query", "owners_is_set"),
 
 					resource.TestCheckResourceAttr(stub.ResourceFullName(), "evaluation.window", "24"),


### PR DESCRIPTION
This was addressed in #45 but regressed in #46 after changes to the acceptance testing flow.

Category is deprecated in the Cortex API and the provider will need an update to adopt the newer filtering approach.  In the meantime, we just remove the feature from acceptance testing and mark it as deprecated.