### PR TITLE
Fix for broken integration test

### DIFF
--- a/examples/resources/catalog_entity_openapi/resource.tf
+++ b/examples/resources/catalog_entity_openapi/resource.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 provider "cortex" {
-  token = "access-token-here"
+  token = "access-token-here" # or set CORTEX_API_TOKEN env var
 }
 
 resource "cortex_catalog_entity_openapi" "test_service_oas1" {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.1
 
 require (
 	github.com/dghubble/sling v1.4.1
+	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
 	github.com/hashicorp/terraform-plugin-framework v1.4.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
@@ -29,7 +30,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/internal/provider/catalog_entity_openapi_resource.go
+++ b/internal/provider/catalog_entity_openapi_resource.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"encoding/json"
-
 	"github.com/cortexapps/terraform-provider-cortex/internal/cortex"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -14,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -108,33 +105,6 @@ func (r *CatalogEntityOpenAPIResource) Create(ctx context.Context, req resource.
 	resp.Diagnostics.Append(diags...)
 }
 
-func normalizeSpec(spec string) (string, error) {
-	// Try to unmarshal as JSON first
-	var data interface{}
-	err := json.Unmarshal([]byte(spec), &data)
-	if err == nil {
-		// If it was JSON, convert to YAML
-		yamlBytes, err := yaml.Marshal(data)
-		if err != nil {
-			return "", fmt.Errorf("failed to convert JSON to YAML: %v", err)
-		}
-		return string(yamlBytes), nil
-	}
-
-	// If it wasn't JSON, try YAML
-	err = yaml.Unmarshal([]byte(spec), &data)
-	if err != nil {
-		return "", fmt.Errorf("spec is neither valid JSON nor YAML: %v", err)
-	}
-
-	// Re-marshal as YAML to ensure consistent formatting
-	yamlBytes, err := yaml.Marshal(data)
-	if err != nil {
-		return "", fmt.Errorf("failed to normalize YAML: %v", err)
-	}
-	return string(yamlBytes), nil
-}
-
 func (r *CatalogEntityOpenAPIResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state CatalogEntityOpenAPIResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -157,16 +127,7 @@ func (r *CatalogEntityOpenAPIResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 
-	normalizedSpec, err := normalizeSpec(openAPISpec.Spec)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error normalizing OpenAPI specification",
-			fmt.Sprintf("Could not normalize OpenAPI specification: %s", err.Error()),
-		)
-		return
-	}
-
-	state.Spec = types.StringValue(normalizedSpec)
+	state.Spec = types.StringValue(openAPISpec.Spec)
 	state.Id = types.StringValue(openAPISpec.ID())
 
 	diags = resp.State.Set(ctx, state)

--- a/internal/provider/catalog_entity_openapi_resource_test.go
+++ b/internal/provider/catalog_entity_openapi_resource_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestAccCatalogEntityOpenAPIResource(t *testing.T) {
@@ -36,7 +39,8 @@ paths:
 servers:
     - url: /
 `
-
+	expectedSpec := `{"info":{"title":"Test API","version":"1.0.0"},"paths":{"/test":{"get":{"responses":{"200":{"description":"OK"}}}}},"openapi":"3.0.0","servers":[{"url":"/"}]}`
+	expectedUpdatedSpec := `{"info":{"title":"Updated Test API","version":"1.0.1"},"paths":{"/test":{"get":{"responses":{"200":{"description":"OK"}}}}},"openapi":"3.0.0","servers":[{"url":"/"}]}`
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -45,6 +49,56 @@ servers:
 			{
 				Config: testAccCatalogEntityOpenAPIResourceConfig(entityTag, spec),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "entity_tag", entityTag),
+					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "spec", expectedSpec),
+					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "id", entityTag),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "cortex_catalog_entity_openapi.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccCatalogEntityOpenAPIResourceConfig(entityTag, updatedSpec),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "entity_tag", entityTag),
+					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "spec", expectedUpdatedSpec),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccCatalogEntityOpenAPIResourceJSON(t *testing.T) {
+	entityTag := "test-service"
+	spec := `{"info":{"title":"Test API","version":"1.0.0"},"paths":{"/test":{"get":{"responses":{"200":{"description":"OK"}}}}},"openapi":"3.0.0","servers":[{"url":"/"}]}`
+
+	updatedSpec := `{"info":{"title":"UpdatedTest API","version":"1.0.1"},"paths":{"/test":{"get":{"responses":{"200":{"description":"OK"}}}}},"openapi":"3.0.0","servers":[{"url":"/"}]}`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccCatalogEntityOpenAPIResourceConfig(entityTag, spec),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.ComposeTestCheckFunc(
+						func(s *terraform.State) error {
+							rs := s.RootModule().Resources["cortex_catalog_entity_openapi.test"]
+							actual := rs.Primary.Attributes["spec"]
+							expected := spec
+
+							if diff := cmp.Diff(expected, actual); diff != "" {
+								t.Errorf("attribute mismatch (-expected +actual):\n%s", diff)
+							}
+
+							return nil
+						},
+					),
 					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "entity_tag", entityTag),
 					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "spec", spec),
 					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "id", entityTag),

--- a/internal/provider/catalog_entity_openapi_resource_test.go
+++ b/internal/provider/catalog_entity_openapi_resource_test.go
@@ -12,69 +12,6 @@ import (
 
 func TestAccCatalogEntityOpenAPIResource(t *testing.T) {
 	entityTag := "test-service"
-	spec := `info:
-    title: Test API
-    version: 1.0.0
-openapi: 3.0.0
-paths:
-    /test:
-        get:
-            responses:
-                "200":
-                    description: OK
-servers:
-    - url: /
-`
-
-	updatedSpec := `info:
-    title: Updated Test API
-    version: 1.0.1
-openapi: 3.0.0
-paths:
-    /test:
-        get:
-            responses:
-                "200":
-                    description: OK
-servers:
-    - url: /
-`
-	expectedSpec := `{"info":{"title":"Test API","version":"1.0.0"},"paths":{"/test":{"get":{"responses":{"200":{"description":"OK"}}}}},"openapi":"3.0.0","servers":[{"url":"/"}]}`
-	expectedUpdatedSpec := `{"info":{"title":"Updated Test API","version":"1.0.1"},"paths":{"/test":{"get":{"responses":{"200":{"description":"OK"}}}}},"openapi":"3.0.0","servers":[{"url":"/"}]}`
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create and Read testing
-			{
-				Config: testAccCatalogEntityOpenAPIResourceConfig(entityTag, spec),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "entity_tag", entityTag),
-					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "spec", expectedSpec),
-					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "id", entityTag),
-				),
-			},
-			// ImportState testing
-			{
-				ResourceName:      "cortex_catalog_entity_openapi.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update and Read testing
-			{
-				Config: testAccCatalogEntityOpenAPIResourceConfig(entityTag, updatedSpec),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "entity_tag", entityTag),
-					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "spec", expectedUpdatedSpec),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-
-func TestAccCatalogEntityOpenAPIResourceJSON(t *testing.T) {
-	entityTag := "test-service"
 	spec := `{"info":{"title":"Test API","version":"1.0.0"},"paths":{"/test":{"get":{"responses":{"200":{"description":"OK"}}}}},"openapi":"3.0.0","servers":[{"url":"/"}]}`
 
 	updatedSpec := `{"info":{"title":"UpdatedTest API","version":"1.0.1"},"paths":{"/test":{"get":{"responses":{"200":{"description":"OK"}}}}},"openapi":"3.0.0","servers":[{"url":"/"}]}`

--- a/internal/provider/catalog_entity_openapi_resource_test.go
+++ b/internal/provider/catalog_entity_openapi_resource_test.go
@@ -9,27 +9,33 @@ import (
 
 func TestAccCatalogEntityOpenAPIResource(t *testing.T) {
 	entityTag := "test-service"
-	spec := `openapi: 3.0.0
-info:
-  title: Test API
-  version: 1.0.0
+	spec := `info:
+    title: Test API
+    version: 1.0.0
+openapi: 3.0.0
 paths:
-  /test:
-    get:
-      responses:
-        '200':
-          description: OK`
+    /test:
+        get:
+            responses:
+                "200":
+                    description: OK
+servers:
+    - url: /
+`
 
-	updatedSpec := `openapi: 3.0.0
-info:
-  title: Updated Test API
-  version: 1.0.1
+	updatedSpec := `info:
+    title: Updated Test API
+    version: 1.0.1
+openapi: 3.0.0
 paths:
-  /test:
-    get:
-      responses:
-        '200':
-          description: OK`
+    /test:
+        get:
+            responses:
+                "200":
+                    description: OK
+servers:
+    - url: /
+`
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/catalog_entity_openapi_resource_test.go
+++ b/internal/provider/catalog_entity_openapi_resource_test.go
@@ -5,9 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestAccCatalogEntityOpenAPIResource(t *testing.T) {
@@ -23,19 +20,6 @@ func TestAccCatalogEntityOpenAPIResource(t *testing.T) {
 			{
 				Config: testAccCatalogEntityOpenAPIResourceConfig(entityTag, spec),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.ComposeTestCheckFunc(
-						func(s *terraform.State) error {
-							rs := s.RootModule().Resources["cortex_catalog_entity_openapi.test"]
-							actual := rs.Primary.Attributes["spec"]
-							expected := spec
-
-							if diff := cmp.Diff(expected, actual); diff != "" {
-								t.Errorf("attribute mismatch (-expected +actual):\n%s", diff)
-							}
-
-							return nil
-						},
-					),
 					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "entity_tag", entityTag),
 					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "spec", spec),
 					resource.TestCheckResourceAttr("cortex_catalog_entity_openapi.test", "id", entityTag),


### PR DESCRIPTION
This merge requests modifies the existing tests to match existing test data in the test instance of Cortex that is used for the integration tests.  

- [x] Integration tests pass
- [x] Example works 