### PR TITLE
feat: return team members and slack channels in team data source

### DIFF
--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -22,3 +22,23 @@ Team data source
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `members` (Attributes List) List of team members. (see [below for nested schema](#nestedatt--members))
+- `slack_channels` (Attributes List) List of Slack channels associated with the team. (see [below for nested schema](#nestedatt--slack_channels))
+
+<a id="nestedatt--members"></a>
+### Nested Schema for `members`
+
+Read-Only:
+
+- `description` (String)
+- `email` (String)
+- `name` (String)
+
+
+<a id="nestedatt--slack_channels"></a>
+### Nested Schema for `slack_channels`
+
+Read-Only:
+
+- `name` (String)
+- `notifications_enabled` (Boolean)

--- a/internal/cortex/teams.go
+++ b/internal/cortex/teams.go
@@ -41,6 +41,7 @@ type Team struct {
 	SlackChannels     []TeamSlackChannel `json:"slackChannels,omitempty"`
 	Links             []TeamLink         `json:"links,omitempty"`
 	TeamTag           string             `json:"teamTag"`
+	CortexTeam        TeamCortexManaged  `json:"cortexTeam,omitempty"`
 }
 
 type TeamMetadata struct {
@@ -50,9 +51,9 @@ type TeamMetadata struct {
 }
 
 type TeamMember struct {
-	Description string `json:"description,omitempty"`
-	Name        string `json:"name"`
-	Email       string `json:"email"`
+	Description string `json:"description,omitempty" tfsdk:"description"`
+	Name        string `json:"name" tfsdk:"name"`
+	Email       string `json:"email" tfsdk:"email"`
 }
 
 type TeamLink struct {
@@ -63,8 +64,8 @@ type TeamLink struct {
 }
 
 type TeamSlackChannel struct {
-	Name                 string `json:"name"`
-	NotificationsEnabled bool   `json:"notificationsEnabled"`
+	Name                 string `json:"name" tfsdk:"name"`
+	NotificationsEnabled bool   `json:"notificationsEnabled" tfsdk:"notifications_enabled"`
 }
 
 type TeamIdpGroup struct {

--- a/internal/provider/team_data_source.go
+++ b/internal/provider/team_data_source.go
@@ -23,9 +23,9 @@ type TeamDataSource struct {
 
 // TeamDataSourceModel describes the data source data model.
 type TeamDataSourceModel struct {
-	Id            types.String           `tfsdk:"id"`
-	Tag           types.String           `tfsdk:"tag"`
-	Members       []cortex.TeamMember    `tfsdk:"members"`
+	Id            types.String              `tfsdk:"id"`
+	Tag           types.String              `tfsdk:"tag"`
+	Members       []cortex.TeamMember       `tfsdk:"members"`
 	SlackChannels []cortex.TeamSlackChannel `tfsdk:"slack_channels"`
 }
 
@@ -123,17 +123,8 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	data.Id = types.StringValue(teamResponse.TeamTag)
 	data.Tag = types.StringValue(teamResponse.TeamTag)
 
-	if teamResponse.CortexTeam.Members != nil {
-		data.Members = teamResponse.CortexTeam.Members
-	} else {
-		data.Members = nil
-	}
-
-	if teamResponse.SlackChannels != nil {
-		data.SlackChannels = teamResponse.SlackChannels
-	} else {
-		data.SlackChannels = nil
-	}
+	data.Members = teamResponse.CortexTeam.Members
+	data.SlackChannels = teamResponse.SlackChannels
 
 	// Write to TF state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/team_data_source.go
+++ b/internal/provider/team_data_source.go
@@ -23,8 +23,10 @@ type TeamDataSource struct {
 
 // TeamDataSourceModel describes the data source data model.
 type TeamDataSourceModel struct {
-	Id  types.String `tfsdk:"id"`
-	Tag types.String `tfsdk:"tag"`
+	Id            types.String           `tfsdk:"id"`
+	Tag           types.String           `tfsdk:"tag"`
+	Members       []cortex.TeamMember    `tfsdk:"members"`
+	SlackChannels []cortex.TeamSlackChannel `tfsdk:"slack_channels"`
 }
 
 func (d *TeamDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -46,6 +48,37 @@ func (d *TeamDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 			// Computed
 			"id": schema.StringAttribute{
 				Computed: true,
+			},
+			"members": schema.ListNestedAttribute{
+				MarkdownDescription: "List of team members.",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+						"email": schema.StringAttribute{
+							Computed: true,
+						},
+						"description": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+			"slack_channels": schema.ListNestedAttribute{
+				MarkdownDescription: "List of Slack channels associated with the team.",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+						"notifications_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -86,8 +119,21 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read team, got error: %s", err))
 		return
 	}
+
 	data.Id = types.StringValue(teamResponse.TeamTag)
 	data.Tag = types.StringValue(teamResponse.TeamTag)
+
+	if teamResponse.CortexTeam.Members != nil {
+		data.Members = teamResponse.CortexTeam.Members
+	} else {
+		data.Members = nil
+	}
+
+	if teamResponse.SlackChannels != nil {
+		data.SlackChannels = teamResponse.SlackChannels
+	} else {
+		data.SlackChannels = nil
+	}
 
 	// Write to TF state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/team_data_source_test.go
+++ b/internal/provider/team_data_source_test.go
@@ -1,23 +1,33 @@
 package provider_test
 
-//func TestAccTeamDataSource(t *testing.T) {
-//	resource.Test(t, resource.TestCase{
-//		PreCheck:                 func() { testAccPreCheck(t) },
-//		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-//		Steps: []resource.TestStep{
-//			// Read testing
-//			{
-//				Config: testAccTeamDataSourceConfig,
-//				Check: resource.ComposeAggregateTestCheckFunc(
-//					resource.TestCheckResourceAttr("data.cortex_team.platform_engineering", "tag", "platform_engineering"),
-//				),
-//			},
-//		},
-//	})
-//}
-//
-//const testAccTeamDataSourceConfig = `
-//data "cortex_team" "engineering" {
-//  tag = "platform_engineering"
-//}
-//`
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccTeamDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read testing
+			{
+				Config: testAccTeamDataSourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.cortex_team.engineering", "tag", "platform_engineering"),
+					resource.TestCheckResourceAttrSet("data.cortex_team.engineering", "members.0.name"),
+					resource.TestCheckResourceAttrSet("data.cortex_team.engineering", "members.0.email"),
+					resource.TestCheckResourceAttrSet("data.cortex_team.engineering", "slack_channels.0.name"),
+					resource.TestCheckResourceAttrSet("data.cortex_team.engineering", "slack_channels.0.notifications_enabled"),
+				),
+			},
+		},
+	})
+}
+
+const testAccTeamDataSourceConfig = `
+data "cortex_team" "engineering" {
+  tag = "platform_engineering"
+}
+`

--- a/internal/provider/team_data_source_test.go
+++ b/internal/provider/team_data_source_test.go
@@ -35,7 +35,7 @@ func TestAccTeamDataSource(t *testing.T) {
 	stub := TestTeamDataSource{
 		Tag: "test-team",
 		Members: []cortex.TeamMember{
-			{Name: "max", Email: "mcai@etsy.com"},
+			{Name: "Test User", Email: "test@example.com"},
 		},
 		SlackChannels: []cortex.TeamSlackChannel{
 			{Name: "test-channel", NotificationsEnabled: true},

--- a/internal/provider/team_data_source_test.go
+++ b/internal/provider/team_data_source_test.go
@@ -3,31 +3,59 @@ package provider_test
 import (
 	"testing"
 
+	"github.com/cortexapps/terraform-provider-cortex/internal/cortex"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+type TestTeamDataSource struct {
+	Tag           string
+	Members       []cortex.TeamMember
+	SlackChannels []cortex.TeamSlackChannel
+}
+
+func (t *TestTeamDataSource) ToStubTeam() *cortex.Team {
+	return &cortex.Team{
+		TeamTag: t.Tag,
+		CortexTeam: cortex.TeamCortexManaged{
+			Members: t.Members,
+		},
+		SlackChannels: t.SlackChannels,
+	}
+}
+
+func testAccTeamDataSourceConfig(tag string) string {
+	return `
+data "cortex_team" "test-team" {
+  tag = "` + tag + `"
+}
+`
+}
+
 func TestAccTeamDataSource(t *testing.T) {
+	stub := TestTeamDataSource{
+		Tag: "test-team",
+		Members: []cortex.TeamMember{
+			{Name: "max", Email: "mcai@etsy.com"},
+		},
+		SlackChannels: []cortex.TeamSlackChannel{
+			{Name: "test-channel", NotificationsEnabled: true},
+		},
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Read testing
 			{
-				Config: testAccTeamDataSourceConfig,
+				Config: testAccTeamDataSourceConfig(stub.Tag),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cortex_team.engineering", "tag", "platform_engineering"),
-					resource.TestCheckResourceAttrSet("data.cortex_team.engineering", "members.0.name"),
-					resource.TestCheckResourceAttrSet("data.cortex_team.engineering", "members.0.email"),
-					resource.TestCheckResourceAttrSet("data.cortex_team.engineering", "slack_channels.0.name"),
-					resource.TestCheckResourceAttrSet("data.cortex_team.engineering", "slack_channels.0.notifications_enabled"),
+					resource.TestCheckResourceAttr("data.cortex_team.test-team", "tag", stub.Tag),
+					resource.TestCheckResourceAttr("data.cortex_team.test-team", "members.0.name", stub.Members[0].Name),
+					resource.TestCheckResourceAttr("data.cortex_team.test-team", "members.0.email", stub.Members[0].Email),
+					resource.TestCheckResourceAttr("data.cortex_team.test-team", "slack_channels.0.name", stub.SlackChannels[0].Name),
+					resource.TestCheckResourceAttr("data.cortex_team.test-team", "slack_channels.0.notifications_enabled", "true"),
 				),
 			},
 		},
 	})
 }
-
-const testAccTeamDataSourceConfig = `
-data "cortex_team" "engineering" {
-  tag = "platform_engineering"
-}
-`


### PR DESCRIPTION
# Summary

This pull request enhances the Terraform Cortex provider by improving the team data source to return both team members and Slack channels. 
It also addresses a compatibility issue with the Terraform Plugin Framework by ensuring all struct fields used for schema mapping have the required tfsdk struct tags.

# Changes

* Feature:
  * The team data source now returns detailed information about team members and Slack channels, making it easier for users to access and utilize this data in their Terraform configurations.
* Bugfix / Compatibility:
  * Added tfsdk struct tags to the TeamSlackChannel struct fields in internal/cortex/teams.go to resolve errors related to missing struct tags required by the Terraform Plugin Framework.

# Motivation
https://github.com/cortexapps/terraform-provider-cortex/issues/52

# Testing

Verified that the team data source now returns both team members and Slack channels as expected.

```
provider "cortex" {
  token = "..."
}

data "cortex_team" "team" {
  tag = "..."
}

output "team" {
  value = data.cortex_team.squad
}
```

```
Changes to Outputs:
  + team = {
      + id             = "..."
      + members        = [
          + {
              + description = "..."
              + email       = "..."
              + name        = "..."
            },
...
        ]
      + slack_channels = [
          + {
              + name                  = "..."
              + notifications_enabled = true
            },
          + {
              + name                  = "..."
              + notifications_enabled = false
            },
        ]
      + tag            = "..."
    }
```

