### PR TITLE
Allow for more info to be retrued on catalog entities data source

### DIFF
--- a/docs/data-sources/catalog_entities.md
+++ b/docs/data-sources/catalog_entities.md
@@ -20,7 +20,7 @@ Catalog Entities data source - returns a list of catalog entities that match the
 - `git_repositories` (List of String) Filter by GitHub repositories in the 'org/repo' format
 - `groups` (List of String) Filter based on groups, which correspond to the x-cortex-groups field in the Catalog Descriptor
 - `include_archived` (Boolean) Whether to include archived entities in the response
-- `include_owners` (Boolean) When true, each entity in the response will include ownership group information. Corresponds to the `includeOwners` API parameter.
+- `include_owners` (Boolean) When true, each entity in the response will include ownership information (teams and individuals). Corresponds to the `includeOwners` API parameter.
 - `owners` (List of String) Filter based on owner group names, which correspond to the x-cortex-owners field in the Catalog Descriptor
 - `query` (String) Filter based on a search query. This will search across entity properties. If provided, results will be sorted by relevance.
 - `types` (List of String) Filter the response to specific types of entities (e.g., service, resource, domain)
@@ -57,7 +57,8 @@ Read-Only:
 
 Read-Only:
 
-- `groups` (Attributes List) List of owning groups for the entity (see [below for nested schema](#nestedatt--entities--ownership--groups))
+- `groups` (Attributes List) List of owning teams for the entity (see [below for nested schema](#nestedatt--entities--ownership--groups))
+- `individuals` (Attributes List) List of individual owners for the entity (see [below for nested schema](#nestedatt--entities--ownership--individuals))
 
 <a id="nestedatt--entities--ownership--groups"></a>
 ### Nested Schema for `entities.ownership.groups`
@@ -67,3 +68,12 @@ Read-Only:
 - `description` (String) Description of this ownership entry
 - `group_name` (String) Tag of the owning team
 - `provider` (String) Provider for this group (e.g., GITHUB, OKTA)
+
+
+<a id="nestedatt--entities--ownership--individuals"></a>
+### Nested Schema for `entities.ownership.individuals`
+
+Read-Only:
+
+- `description` (String) Description of this ownership entry
+- `email` (String) Email address of the individual owner

--- a/docs/data-sources/catalog_entities.md
+++ b/docs/data-sources/catalog_entities.md
@@ -20,6 +20,7 @@ Catalog Entities data source - returns a list of catalog entities that match the
 - `git_repositories` (List of String) Filter by GitHub repositories in the 'org/repo' format
 - `groups` (List of String) Filter based on groups, which correspond to the x-cortex-groups field in the Catalog Descriptor
 - `include_archived` (Boolean) Whether to include archived entities in the response
+- `include_owners` (Boolean) When true, each entity in the response will include ownership group information. Corresponds to the `includeOwners` API parameter.
 - `owners` (List of String) Filter based on owner group names, which correspond to the x-cortex-owners field in the Catalog Descriptor
 - `query` (String) Filter based on a search query. This will search across entity properties. If provided, results will be sorted by relevance.
 - `types` (List of String) Filter the response to specific types of entities (e.g., service, resource, domain)
@@ -35,6 +36,34 @@ Catalog Entities data source - returns a list of catalog entities that match the
 Read-Only:
 
 - `description` (String) Description of the entity visible in the Service or Resource Catalog
+- `git` (Attributes) Git repository information for the entity. Populated when a git integration is configured. (see [below for nested schema](#nestedatt--entities--git))
 - `name` (String) Human-readable name for the entity
+- `ownership` (Attributes) Ownership information for the entity. Populated when `include_owners` is true. (see [below for nested schema](#nestedatt--entities--ownership))
 - `tag` (String) Tag of the catalog entity
 - `type` (String) Type of the entity (e.g., service, resource, domain)
+
+<a id="nestedatt--entities--git"></a>
+### Nested Schema for `entities.git`
+
+Read-Only:
+
+- `provider` (String) Git provider (e.g., GITHUB, GITLAB)
+- `repository` (String) Repository name in org/repo format
+- `repository_url` (String) Full URL to the repository
+
+
+<a id="nestedatt--entities--ownership"></a>
+### Nested Schema for `entities.ownership`
+
+Read-Only:
+
+- `groups` (Attributes List) List of owning groups for the entity (see [below for nested schema](#nestedatt--entities--ownership--groups))
+
+<a id="nestedatt--entities--ownership--groups"></a>
+### Nested Schema for `entities.ownership.groups`
+
+Read-Only:
+
+- `description` (String) Description of this ownership entry
+- `group_name` (String) Tag of the owning team
+- `provider` (String) Provider for this group (e.g., GITHUB, OKTA)

--- a/examples/data-sources/catalog_entities/data-source.tf
+++ b/examples/data-sources/catalog_entities/data-source.tf
@@ -61,3 +61,12 @@ output "entity_owners" {
     if entity.ownership != null && length(entity.ownership.groups) > 0
   }
 }
+
+# Access individual owners for each service (requires include_owners = true)
+output "entity_individual_owners" {
+  value = {
+    for entity in data.cortex_catalog_entities.services_with_owners.entities :
+    entity.tag => [for ind in entity.ownership.individuals : ind.email]
+    if entity.ownership != null && length(entity.ownership.individuals) > 0
+  }
+}

--- a/examples/data-sources/catalog_entities/data-source.tf
+++ b/examples/data-sources/catalog_entities/data-source.tf
@@ -30,6 +30,12 @@ data "cortex_catalog_entities" "all_including_archived" {
   include_archived = true
 }
 
+# Include ownership information for each entity
+data "cortex_catalog_entities" "services_with_owners" {
+  types          = ["service"]
+  include_owners = true
+}
+
 # Access the list of entities
 output "entity_tags" {
   value = [for entity in data.cortex_catalog_entities.all_services.entities : entity.tag]
@@ -37,4 +43,21 @@ output "entity_tags" {
 
 output "entity_names" {
   value = [for entity in data.cortex_catalog_entities.all_services.entities : entity.name]
+}
+
+# Access git repository for each service (null if no git integration is configured)
+output "entity_git_repositories" {
+  value = {
+    for entity in data.cortex_catalog_entities.all_services.entities :
+    entity.tag => entity.git.repository if entity.git != null
+  }
+}
+
+# Access the first owning team tag for each service (requires include_owners = true)
+output "entity_owners" {
+  value = {
+    for entity in data.cortex_catalog_entities.services_with_owners.entities :
+    entity.tag => entity.ownership.groups[0].group_name
+    if entity.ownership != null && length(entity.ownership.groups) > 0
+  }
 }

--- a/internal/cortex/catalog_entities.go
+++ b/internal/cortex/catalog_entities.go
@@ -51,6 +51,7 @@ type CatalogEntity struct {
 	Metadata      []CatalogEntityMetadata     `json:"metadata" yaml:"x-cortex-custom-metadata"`
 	Dependencies  []string                    `json:"dependencies" yaml:"x-cortex-dependency"`
 	Ownership     CatalogEntityOwnership      `json:"ownership" yaml:"x-cortex-owners"`
+	Owners        CatalogEntityOwnersResponse `json:"owners"`
 	SlackChannels []CatalogEntitySlackChannel `json:"slackChannels"`
 	Git           CatalogEntityGitSummary     `json:"git"`
 }
@@ -69,6 +70,27 @@ type CatalogEntitySlackChannel struct {
 	Name                 string `json:"name"`
 	Description          string `json:"description"`
 	NotificationsEnabled bool   `json:"notificationsEnabled"`
+}
+
+// CatalogEntityOwnersResponse is the ownership data returned by the list endpoint when
+// includeOwners=true. This is distinct from CatalogEntityOwnership (used by the single-entity
+// GET) — the list endpoint nests owners under "owners" with "teams" and "individuals" arrays.
+type CatalogEntityOwnersResponse struct {
+	Teams       []CatalogEntityOwnerTeam       `json:"teams"`
+	Individuals []CatalogEntityOwnerIndividual `json:"individuals"`
+}
+
+type CatalogEntityOwnerTeam struct {
+	Name        string `json:"name"`
+	Tag         string `json:"tag"`
+	Description string `json:"description"`
+	Provider    string `json:"provider"`
+	Inheritance string `json:"inheritance"`
+}
+
+type CatalogEntityOwnerIndividual struct {
+	Email       string `json:"email"`
+	Description string `json:"description"`
 }
 
 type CatalogEntityMetadata struct {
@@ -176,6 +198,7 @@ type CatalogEntityListParams struct {
 	GitRepositories []string `url:"gitRepositories,omitempty,comma"`
 	Query           string   `url:"query,omitempty"`
 	IncludeArchived bool     `url:"includeArchived,omitempty"`
+	IncludeOwners   bool     `url:"includeOwners,omitempty"`
 	PageSize        int      `url:"pageSize,omitempty"`
 	Page            int      `url:"page,omitempty"`
 }

--- a/internal/cortex/catalog_entities_test.go
+++ b/internal/cortex/catalog_entities_test.go
@@ -39,3 +39,22 @@ func TestListCatalogEntities(t *testing.T) {
 	assert.NotEmpty(t, res.Entities, "returned no entities")
 	assert.Equal(t, res.Entities[0].Tag, firstTag)
 }
+
+func TestListCatalogEntitiesWithOwners(t *testing.T) {
+	resp := &cortex.CatalogEntitiesResponse{
+		Entities: []cortex.CatalogEntity{
+			*testCatalogEntity,
+		},
+	}
+	c, teardown, err := setupClient(cortex.Route("catalog_entities", ""), resp,
+		AssertRequestMethod(t, "GET"),
+		AssertRequestURI(t, "/api/v1/catalog/?includeOwners=true"),
+	)
+	assert.Nil(t, err, "could not setup client")
+	defer teardown()
+
+	queryParams := cortex.CatalogEntityListParams{IncludeOwners: true}
+	res, err := c.CatalogEntities().List(context.Background(), &queryParams)
+	assert.Nil(t, err, "error retrieving entities")
+	assert.NotEmpty(t, res.Entities, "returned no entities")
+}

--- a/internal/cortex/catalog_entities_test.go
+++ b/internal/cortex/catalog_entities_test.go
@@ -58,3 +58,58 @@ func TestListCatalogEntitiesWithOwners(t *testing.T) {
 	assert.Nil(t, err, "error retrieving entities")
 	assert.NotEmpty(t, res.Entities, "returned no entities")
 }
+
+func TestListCatalogEntitiesDeserializesOwnersAndGit(t *testing.T) {
+	entity := cortex.CatalogEntity{
+		Tag: "test-catalog-entity",
+		Owners: cortex.CatalogEntityOwnersResponse{
+			Teams: []cortex.CatalogEntityOwnerTeam{
+				{
+					Name:        "My Team",
+					Tag:         "my-team",
+					Description: "Owns core services",
+					Provider:    "GITHUB",
+					Inheritance: "NONE",
+				},
+			},
+			Individuals: []cortex.CatalogEntityOwnerIndividual{
+				{
+					Email:       "owner@example.com",
+					Description: "Lead engineer",
+				},
+			},
+		},
+		Git: cortex.CatalogEntityGitSummary{
+			Provider:      "GITHUB",
+			Repository:    "my-org/my-repo",
+			RepositoryUrl: "https://github.com/my-org/my-repo",
+		},
+	}
+	resp := &cortex.CatalogEntitiesResponse{
+		Entities: []cortex.CatalogEntity{entity},
+	}
+	c, teardown, err := setupClient(cortex.Route("catalog_entities", ""), resp, AssertRequestMethod(t, "GET"))
+	assert.Nil(t, err, "could not setup client")
+	defer teardown()
+
+	queryParams := cortex.CatalogEntityListParams{IncludeOwners: true}
+	res, err := c.CatalogEntities().List(context.Background(), &queryParams)
+	assert.Nil(t, err, "error retrieving entities")
+	assert.Len(t, res.Entities, 1)
+
+	got := res.Entities[0]
+
+	assert.Len(t, got.Owners.Teams, 1)
+	assert.Equal(t, "my-team", got.Owners.Teams[0].Tag)
+	assert.Equal(t, "My Team", got.Owners.Teams[0].Name)
+	assert.Equal(t, "GITHUB", got.Owners.Teams[0].Provider)
+	assert.Equal(t, "NONE", got.Owners.Teams[0].Inheritance)
+
+	assert.Len(t, got.Owners.Individuals, 1)
+	assert.Equal(t, "owner@example.com", got.Owners.Individuals[0].Email)
+	assert.Equal(t, "Lead engineer", got.Owners.Individuals[0].Description)
+
+	assert.Equal(t, "GITHUB", got.Git.Provider)
+	assert.Equal(t, "my-org/my-repo", got.Git.Repository)
+	assert.Equal(t, "https://github.com/my-org/my-repo", got.Git.RepositoryUrl)
+}

--- a/internal/provider/catalog_entities_data_source.go
+++ b/internal/provider/catalog_entities_data_source.go
@@ -53,14 +53,21 @@ type CatalogEntityGitItemModel struct {
 
 // CatalogEntityOwnershipItemModel holds ownership data for a catalog entity item.
 type CatalogEntityOwnershipItemModel struct {
-	Groups []CatalogEntityOwnershipGroupItemModel `tfsdk:"groups"`
+	Groups      []CatalogEntityOwnershipGroupItemModel      `tfsdk:"groups"`
+	Individuals []CatalogEntityOwnershipIndividualItemModel `tfsdk:"individuals"`
 }
 
-// CatalogEntityOwnershipGroupItemModel represents a single owning group for a catalog entity.
+// CatalogEntityOwnershipGroupItemModel represents a single owning team for a catalog entity.
 type CatalogEntityOwnershipGroupItemModel struct {
 	GroupName   types.String `tfsdk:"group_name"`
 	Description types.String `tfsdk:"description"`
 	Provider    types.String `tfsdk:"provider"`
+}
+
+// CatalogEntityOwnershipIndividualItemModel represents a single individual owner for a catalog entity.
+type CatalogEntityOwnershipIndividualItemModel struct {
+	Email       types.String `tfsdk:"email"`
+	Description types.String `tfsdk:"description"`
 }
 
 func (d *CatalogEntitiesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -105,7 +112,7 @@ func (d *CatalogEntitiesDataSource) Schema(ctx context.Context, req datasource.S
 				Optional:            true,
 			},
 			"include_owners": schema.BoolAttribute{
-				MarkdownDescription: "When true, each entity in the response will include ownership group information. Corresponds to the `includeOwners` API parameter.",
+				MarkdownDescription: "When true, each entity in the response will include ownership information (teams and individuals). Corresponds to the `includeOwners` API parameter.",
 				Optional:            true,
 			},
 			"entities": schema.ListNestedAttribute{
@@ -152,7 +159,7 @@ func (d *CatalogEntitiesDataSource) Schema(ctx context.Context, req datasource.S
 							Computed:            true,
 							Attributes: map[string]schema.Attribute{
 								"groups": schema.ListNestedAttribute{
-									MarkdownDescription: "List of owning groups for the entity",
+									MarkdownDescription: "List of owning teams for the entity",
 									Computed:            true,
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
@@ -166,6 +173,22 @@ func (d *CatalogEntitiesDataSource) Schema(ctx context.Context, req datasource.S
 											},
 											"provider": schema.StringAttribute{
 												MarkdownDescription: "Provider for this group (e.g., GITHUB, OKTA)",
+												Computed:            true,
+											},
+										},
+									},
+								},
+								"individuals": schema.ListNestedAttribute{
+									MarkdownDescription: "List of individual owners for the entity",
+									Computed:            true,
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"email": schema.StringAttribute{
+												MarkdownDescription: "Email address of the individual owner",
+												Computed:            true,
+											},
+											"description": schema.StringAttribute{
+												MarkdownDescription: "Description of this ownership entry",
 												Computed:            true,
 											},
 										},
@@ -301,9 +324,9 @@ func (d *CatalogEntitiesDataSource) Read(ctx context.Context, req datasource.Rea
 			}
 		}
 
-		// Ownership teams are populated when include_owners is true. The list endpoint returns
-		// owners.teams[] (not ownership.groups[]) so we map from that field.
-		if len(entity.Owners.Teams) > 0 {
+		// Ownership is populated when include_owners is true. The list endpoint returns
+		// owners.teams[] and owners.individuals[] (not ownership.groups[]).
+		if len(entity.Owners.Teams) > 0 || len(entity.Owners.Individuals) > 0 {
 			groups := make([]CatalogEntityOwnershipGroupItemModel, len(entity.Owners.Teams))
 			for j, t := range entity.Owners.Teams {
 				groups[j] = CatalogEntityOwnershipGroupItemModel{
@@ -312,7 +335,14 @@ func (d *CatalogEntitiesDataSource) Read(ctx context.Context, req datasource.Rea
 					Provider:    types.StringValue(t.Provider),
 				}
 			}
-			item.Ownership = &CatalogEntityOwnershipItemModel{Groups: groups}
+			individuals := make([]CatalogEntityOwnershipIndividualItemModel, len(entity.Owners.Individuals))
+			for j, ind := range entity.Owners.Individuals {
+				individuals[j] = CatalogEntityOwnershipIndividualItemModel{
+					Email:       types.StringValue(ind.Email),
+					Description: types.StringValue(ind.Description),
+				}
+			}
+			item.Ownership = &CatalogEntityOwnershipItemModel{Groups: groups, Individuals: individuals}
 		}
 
 		data.Entities[i] = item

--- a/internal/provider/catalog_entities_data_source.go
+++ b/internal/provider/catalog_entities_data_source.go
@@ -36,12 +36,12 @@ type CatalogEntitiesDataSourceModel struct {
 
 // CatalogEntityDataSourceItemModel represents a single entity in the list.
 type CatalogEntityDataSourceItemModel struct {
-	Tag         types.String                          `tfsdk:"tag"`
-	Name        types.String                          `tfsdk:"name"`
-	Description types.String                          `tfsdk:"description"`
-	Type        types.String                          `tfsdk:"type"`
-	Git         *CatalogEntityGitItemModel            `tfsdk:"git"`
-	Ownership   *CatalogEntityOwnershipItemModel      `tfsdk:"ownership"`
+	Tag         types.String                     `tfsdk:"tag"`
+	Name        types.String                     `tfsdk:"name"`
+	Description types.String                     `tfsdk:"description"`
+	Type        types.String                     `tfsdk:"type"`
+	Git         *CatalogEntityGitItemModel       `tfsdk:"git"`
+	Ownership   *CatalogEntityOwnershipItemModel `tfsdk:"ownership"`
 }
 
 // CatalogEntityGitItemModel holds the flat git information returned by the catalog list endpoint.

--- a/internal/provider/catalog_entities_data_source.go
+++ b/internal/provider/catalog_entities_data_source.go
@@ -30,15 +30,37 @@ type CatalogEntitiesDataSourceModel struct {
 	Types           []types.String                     `tfsdk:"types"`
 	GitRepositories []types.String                     `tfsdk:"git_repositories"`
 	IncludeArchived types.Bool                         `tfsdk:"include_archived"`
+	IncludeOwners   types.Bool                         `tfsdk:"include_owners"`
 	Entities        []CatalogEntityDataSourceItemModel `tfsdk:"entities"`
 }
 
 // CatalogEntityDataSourceItemModel represents a single entity in the list.
 type CatalogEntityDataSourceItemModel struct {
-	Tag         types.String `tfsdk:"tag"`
-	Name        types.String `tfsdk:"name"`
+	Tag         types.String                          `tfsdk:"tag"`
+	Name        types.String                          `tfsdk:"name"`
+	Description types.String                          `tfsdk:"description"`
+	Type        types.String                          `tfsdk:"type"`
+	Git         *CatalogEntityGitItemModel            `tfsdk:"git"`
+	Ownership   *CatalogEntityOwnershipItemModel      `tfsdk:"ownership"`
+}
+
+// CatalogEntityGitItemModel holds the flat git information returned by the catalog list endpoint.
+type CatalogEntityGitItemModel struct {
+	Provider      types.String `tfsdk:"provider"`
+	Repository    types.String `tfsdk:"repository"`
+	RepositoryUrl types.String `tfsdk:"repository_url"`
+}
+
+// CatalogEntityOwnershipItemModel holds ownership data for a catalog entity item.
+type CatalogEntityOwnershipItemModel struct {
+	Groups []CatalogEntityOwnershipGroupItemModel `tfsdk:"groups"`
+}
+
+// CatalogEntityOwnershipGroupItemModel represents a single owning group for a catalog entity.
+type CatalogEntityOwnershipGroupItemModel struct {
+	GroupName   types.String `tfsdk:"group_name"`
 	Description types.String `tfsdk:"description"`
-	Type        types.String `tfsdk:"type"`
+	Provider    types.String `tfsdk:"provider"`
 }
 
 func (d *CatalogEntitiesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -82,6 +104,10 @@ func (d *CatalogEntitiesDataSource) Schema(ctx context.Context, req datasource.S
 				MarkdownDescription: "Whether to include archived entities in the response",
 				Optional:            true,
 			},
+			"include_owners": schema.BoolAttribute{
+				MarkdownDescription: "When true, each entity in the response will include ownership group information. Corresponds to the `includeOwners` API parameter.",
+				Optional:            true,
+			},
 			"entities": schema.ListNestedAttribute{
 				MarkdownDescription: "List of catalog entities that match the search criteria",
 				Computed:            true,
@@ -102,6 +128,50 @@ func (d *CatalogEntitiesDataSource) Schema(ctx context.Context, req datasource.S
 						"type": schema.StringAttribute{
 							MarkdownDescription: "Type of the entity (e.g., service, resource, domain)",
 							Computed:            true,
+						},
+						"git": schema.SingleNestedAttribute{
+							MarkdownDescription: "Git repository information for the entity. Populated when a git integration is configured.",
+							Computed:            true,
+							Attributes: map[string]schema.Attribute{
+								"provider": schema.StringAttribute{
+									MarkdownDescription: "Git provider (e.g., GITHUB, GITLAB)",
+									Computed:            true,
+								},
+								"repository": schema.StringAttribute{
+									MarkdownDescription: "Repository name in org/repo format",
+									Computed:            true,
+								},
+								"repository_url": schema.StringAttribute{
+									MarkdownDescription: "Full URL to the repository",
+									Computed:            true,
+								},
+							},
+						},
+						"ownership": schema.SingleNestedAttribute{
+							MarkdownDescription: "Ownership information for the entity. Populated when `include_owners` is true.",
+							Computed:            true,
+							Attributes: map[string]schema.Attribute{
+								"groups": schema.ListNestedAttribute{
+									MarkdownDescription: "List of owning groups for the entity",
+									Computed:            true,
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"group_name": schema.StringAttribute{
+												MarkdownDescription: "Tag of the owning team",
+												Computed:            true,
+											},
+											"description": schema.StringAttribute{
+												MarkdownDescription: "Description of this ownership entry",
+												Computed:            true,
+											},
+											"provider": schema.StringAttribute{
+												MarkdownDescription: "Provider for this group (e.g., GITHUB, OKTA)",
+												Computed:            true,
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -179,6 +249,10 @@ func (d *CatalogEntitiesDataSource) Read(ctx context.Context, req datasource.Rea
 		params.IncludeArchived = data.IncludeArchived.ValueBool()
 	}
 
+	if !data.IncludeOwners.IsNull() && !data.IncludeOwners.IsUnknown() {
+		params.IncludeOwners = data.IncludeOwners.ValueBool()
+	}
+
 	// Fetch all pages of results
 	allEntities := []cortex.CatalogEntity{}
 	page := 0
@@ -211,12 +285,37 @@ func (d *CatalogEntitiesDataSource) Read(ctx context.Context, req datasource.Rea
 	// Map response to state
 	data.Entities = make([]CatalogEntityDataSourceItemModel, len(allEntities))
 	for i, entity := range allEntities {
-		data.Entities[i] = CatalogEntityDataSourceItemModel{
+		item := CatalogEntityDataSourceItemModel{
 			Tag:         types.StringValue(entity.Tag),
 			Name:        types.StringValue(entity.Name),
 			Description: types.StringValue(entity.Description),
 			Type:        types.StringValue(entity.Type),
 		}
+
+		// Git is returned by default from the list endpoint when a git integration is configured.
+		if entity.Git.Repository != "" {
+			item.Git = &CatalogEntityGitItemModel{
+				Provider:      types.StringValue(entity.Git.Provider),
+				Repository:    types.StringValue(entity.Git.Repository),
+				RepositoryUrl: types.StringValue(entity.Git.RepositoryUrl),
+			}
+		}
+
+		// Ownership teams are populated when include_owners is true. The list endpoint returns
+		// owners.teams[] (not ownership.groups[]) so we map from that field.
+		if len(entity.Owners.Teams) > 0 {
+			groups := make([]CatalogEntityOwnershipGroupItemModel, len(entity.Owners.Teams))
+			for j, t := range entity.Owners.Teams {
+				groups[j] = CatalogEntityOwnershipGroupItemModel{
+					GroupName:   types.StringValue(t.Tag),
+					Description: types.StringValue(t.Description),
+					Provider:    types.StringValue(t.Provider),
+				}
+			}
+			item.Ownership = &CatalogEntityOwnershipItemModel{Groups: groups}
+		}
+
+		data.Entities[i] = item
 	}
 
 	// Set ID as a hash of the query parameters

--- a/internal/provider/catalog_entities_data_source_test.go
+++ b/internal/provider/catalog_entities_data_source_test.go
@@ -53,3 +53,27 @@ data "cortex_catalog_entities" "test" {
 	types = ["service"]
 }`
 }
+
+func TestAccCatalogEntitiesDataSourceWithOwners(t *testing.T) {
+	recordName := "data.cortex_catalog_entities.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogEntitiesDataSourceWithOwners(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(recordName, "entities.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCatalogEntitiesDataSourceWithOwners() string {
+	return `
+data "cortex_catalog_entities" "test" {
+	types          = ["service"]
+	include_owners = true
+}`
+}


### PR DESCRIPTION
Before this change, in order to use a catalog entities ownerhsip and Git information, a follow up call per entity was required. This change allows us to retrieve that information from the single paginated "Entities" data source. 

The Git information was returned by default any way by the API call, so this change just surfaces that information.

The owners info was not previously retrieved and requires adding a param to the API call so this has been added as a toggle to the data source. 

The following test code was used in order to verify the behaviour: 
```
# Get all catalog entities
data "cortex_catalog_entities" "all_entities" {
  types          = ["service"]
  include_owners = true
}

locals {
  service_entity_tags = [
    for entity in data.cortex_catalog_entities.all_entities.entities :
    entity.tag if !strcontains(entity.tag, "//")
  ]

  _service_owner = {
    for entity in data.cortex_catalog_entities.all_entities.entities :
    entity.tag => try(entity.ownership.groups[0].group_name, null)
  }

  # service tag => owning team name (services without an owner are excluded)
  service_entity_owners = { for tag, team in local._service_owner : tag => team if team != null }

  # team name => list of service tags it owns
  team_to_services = { for tag, team in local.service_entity_owners : team => tag... }

  service_to_github = {
    for entity in data.cortex_catalog_entities.all_entities.entities :
    entity.tag => try(entity.git.repository, null)
  }
}

output "ownership_mapping" {
  value = local.service_entity_owners
}

# Output a single service object to see the structure of the data
output "service_object" {
  value = data.cortex_catalog_entities.all_entities.entities[0]
}
```

